### PR TITLE
babel loader instead of ts-loader, type-checking is parallel process …

### DIFF
--- a/config/babel/babelRemovePropsPlugin.ts
+++ b/config/babel/babelRemovePropsPlugin.ts
@@ -1,0 +1,21 @@
+import { PluginItem } from '@babel/core';
+
+export default function (): PluginItem {
+  return {
+    visitor: {
+      Program(path, state) {
+        const forbidden = state.opts.props || [];
+
+        path.traverse({
+          JSXIdentifier(current) {
+            const nodeName = current.node.name;
+
+            if (forbidden.includes(nodeName)) {
+              current.parentPath.remove();
+            }
+          },
+        });
+      },
+    },
+  };
+}

--- a/config/build/loaders/buildBabelLoader.ts
+++ b/config/build/loaders/buildBabelLoader.ts
@@ -1,4 +1,5 @@
 import { BuildOptions } from '../types/config';
+import babelRemovePropsPlugin from '../../babel/babelRemovePropsPlugin';
 
 interface BuildBabelLoaderProps extends BuildOptions {
   isTsx: boolean;
@@ -19,6 +20,12 @@ export function buildBabelLoader(options: BuildBabelLoaderProps) {
               isTsx,
             }],
           '@babel/plugin-transform-runtime',
+          isTsx && [
+            babelRemovePropsPlugin,
+            {
+              props: ['data-testid'],
+            },
+          ],
           isDev && require.resolve('react-refresh/babel')].filter(Boolean),
       },
     },


### PR DESCRIPTION
…with fork-ts-checker library, add custom babel plugin  which removing data-testid from build